### PR TITLE
Added .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.class
+*.DS_Store
 
 /bin/*
 /conf/*


### PR DESCRIPTION
I use a mac and .DS_Store is auto generated in each folder, this will
allow me to not upload a .DS_Store file for each folder. This pull is needed for me to start contributing.
