### PR TITLE
Fix for localization load errors.

### DIFF
--- a/src/FE_SRC_COMMON/com/ForgeEssentials/util/Localization.java
+++ b/src/FE_SRC_COMMON/com/ForgeEssentials/util/Localization.java
@@ -162,12 +162,12 @@ public class Localization
 	public void load()
 	{
 		OutputHandler.SOP("Loading languages");
-		String langDir = "com/ForgeEssentials/util/lang/";
+		String langDir = "/com/ForgeEssentials/util/lang/";
 
 		for (String langFile : langFiles)
 			try
 			{
-				LanguageRegistry.instance().loadLocalization(ClassLoader.getSystemResource(langDir + langFile), langFile.substring(langFile.lastIndexOf('/') + 1, langFile.lastIndexOf('.')), true);
+				LanguageRegistry.instance().loadLocalization(langDir + langFile, langFile.substring(langFile.lastIndexOf('/') + 1, langFile.lastIndexOf('.')), true);
 				OutputHandler.SOP("Loaded language file " + langFile);
 			}
 			catch (Exception e)


### PR DESCRIPTION
Changed to use LocalizationRegistry's String-based loadLocalization, and put the leading forward slash at the front of the langDir.
