### PR TITLE
Update src/FE_SRC_COMMON/com/ForgeEssentials/commands/CommandGive.java

### DIFF
--- a/src/FE_SRC_COMMON/com/ForgeEssentials/commands/CommandGive.java
+++ b/src/FE_SRC_COMMON/com/ForgeEssentials/commands/CommandGive.java
@@ -142,7 +142,7 @@ public class CommandGive extends ForgeEssentialsCommandBase
 			}
 			catch (Exception e)
 			{
-				sender.sendChatToPlayer("The server couldn't find the block you where looking for.");
+				sender.sendChatToPlayer("The server couldn't find the block you were looking for.");
 			}
 		}
 		else


### PR DESCRIPTION
Spelling error: were not where
