### PR TITLE
Little command tweak on chat layout (CommandCapabilities)

### DIFF
--- a/src/FE_SRC_COMMON/com/ForgeEssentials/commands/CommandCapabilities.java
+++ b/src/FE_SRC_COMMON/com/ForgeEssentials/commands/CommandCapabilities.java
@@ -1,6 +1,7 @@
 package com.ForgeEssentials.commands;
 
 import com.ForgeEssentials.core.commands.ForgeEssentialsCommandBase;
+import com.ForgeEssentials.util.FEChatFormatCodes;
 import com.ForgeEssentials.util.FunctionHelper;
 import com.ForgeEssentials.util.Localization;
 import com.ForgeEssentials.util.OutputHandler;
@@ -84,7 +85,7 @@ public class CommandCapabilities extends ForgeEssentialsCommandBase
 			{
 				target = PlayerSelector.matchOnePlayer(sender, args[0]);
 			}
-			
+			sender.sendChatToPlayer(FEChatFormatCodes.GREEN + "Capabilities for " + target.username); //made this green because its a massive wall of text, and unclear whats going on
 			sender.sendChatToPlayer(names.get(0) + " = " + target.capabilities.disableDamage);
 			sender.sendChatToPlayer(names.get(1) + " = " + target.capabilities.isFlying);
 			sender.sendChatToPlayer(names.get(2) + " = " + target.capabilities.allowFlying);


### PR DESCRIPTION
Tweaked the command to it shows the name of the target, and is green
so this is a bit more clear.
![chat](https://f.cloud.github.com/assets/3451587/129187/3470140c-6fd3-11e2-8892-c2cabab4c4e7.PNG)
