### PR TITLE
Fix XP duplication bug in death chests

### DIFF
--- a/src/FE_SRC_CLIENT/com/ForgeEssentials/client/ForgeEssentialsClient.java
+++ b/src/FE_SRC_CLIENT/com/ForgeEssentials/client/ForgeEssentialsClient.java
@@ -28,7 +28,7 @@ public class ForgeEssentialsClient
 
 	private boolean getDevOverride() 
 	{
-		if (System.getProperty("forgeessentials.client.developermode").equals("true")) // FOR DEVS ONLY! THAT IS WHY IT IS A PROPERTY!!!
+		if (System.getProperty("forgeessentials.client.developermode") != null && System.getProperty("forgeessentials.client.developermode").equals("true")) // FOR DEVS ONLY! THAT IS WHY IT IS A PROPERTY!!!
 		return true;
 		else return false;
 	}

--- a/src/FE_SRC_COMMON/com/ForgeEssentials/afterlife/Deathchest.java
+++ b/src/FE_SRC_COMMON/com/ForgeEssentials/afterlife/Deathchest.java
@@ -125,6 +125,11 @@ public class Deathchest
 					else
 					{
 						EntityPlayerMP player = (EntityPlayerMP) e.entityPlayer;
+						if (grave.xp > 0)
+						{
+							player.addExperienceLevel(grave.xp);
+							grave.xp = 0;
+						}
 
 						if (player.openContainer != player.inventoryContainer)
 						{
@@ -182,23 +187,23 @@ public class Deathchest
 				}
 			}
 
-			for (int i = 0; i < 10; i++)
-			{
-				try
-				{
-					int xp = grave.xp / 10;
-					if (xp == 0)
-					{
-						break;
-					}
-					EntityXPOrb entity = new EntityXPOrb(DimensionManager.getWorld(grave.point.dim), grave.point.x, grave.point.y, grave.point.z, xp);
-					DimensionManager.getWorld(grave.point.dim).spawnEntityInWorld(entity);
-				}
-				catch (Exception e)
-				{
-					e.printStackTrace();
-				}
-			}
+//			for (int i = 0; i < 10; i++)
+//			{
+//				try
+//				{
+//					int xp = grave.xp / 10;
+//					if (xp == 0)
+//					{
+//						break;
+//					}
+//					EntityXPOrb entity = new EntityXPOrb(DimensionManager.getWorld(grave.point.dim), grave.point.x, grave.point.y, grave.point.z, xp);
+//					DimensionManager.getWorld(grave.point.dim).spawnEntityInWorld(entity);
+//				}
+//				catch (Exception e)
+//				{
+//					e.printStackTrace();
+//				}
+//			}
 		}
 	}
 }

--- a/src/FE_SRC_COMMON/com/ForgeEssentials/afterlife/Grave.java
+++ b/src/FE_SRC_COMMON/com/ForgeEssentials/afterlife/Grave.java
@@ -46,7 +46,7 @@ public class Grave
 		owner = player.username;
 		if (Deathchest.enableXP)
 		{
-			xp = player.experienceTotal;
+			xp = player.experienceLevel;
 
 			player.experienceLevel = 0;
 			player.experienceTotal = 0;


### PR DESCRIPTION
This happened when something modifies XP Level but not total XP,
reported case was with Ars Magica mod.
