### PR TITLE
Fixes derpy /give autofill.

### DIFF
--- a/src/FE_SRC_COMMON/com/ForgeEssentials/commands/CommandGive.java
+++ b/src/FE_SRC_COMMON/com/ForgeEssentials/commands/CommandGive.java
@@ -28,7 +28,7 @@ public class CommandGive extends FEcmdModuleCommands
 	@Override
 	public void processCommandPlayer(EntityPlayer sender, String[] args)
 	{
-		if (args.length == 2 || args.length > 3)
+		if (args.length < 2 || args.length > 3)
 		{
 			OutputHandler.chatError(sender, Localization.get(Localization.ERROR_BADSYNTAX) + getSyntaxConsole());
 		}


### PR DESCRIPTION
Also wouldn't it make more sense if it was /give RlonRyan 10 stone
instead of /give RlonRyan stone 10? You wouldn't say "I gave RlonRyan stone 10"; you would say "I gave RlonRyan 10 stone".
