### PR TITLE
Take all the moneys

### DIFF
--- a/src/main/java/com/forgeessentials/economy/WalletHandler.java
+++ b/src/main/java/com/forgeessentials/economy/WalletHandler.java
@@ -33,7 +33,7 @@ public class WalletHandler implements IPlayerTracker, IEconManager
 	@Override
 	public void removeFromWallet(int amountToSubtract, String player)
 	{
-		if (wallets.get(player).amount - amountToSubtract > 0){
+		if (wallets.get(player).amount - amountToSubtract >= 0){
 		wallets.get(player).amount = wallets.get(player).amount - amountToSubtract;
 		}
 	}


### PR DESCRIPTION
This used to allow players to pay for items that they just had enough coins for and retain the coins, but still receive the item
