### PR TITLE
Fixes incorrect message being sent

### DIFF
--- a/src/main/java/com/forgeessentials/commands/CommandAFK.java
+++ b/src/main/java/com/forgeessentials/commands/CommandAFK.java
@@ -74,11 +74,11 @@ public class CommandAFK extends FEcmdModuleCommands {
         if (APIRegistry.perms.checkPermAllowed(new PermQueryPlayer(afkData.player, NOTICEPERM)))
         {
             ChatUtils.sendMessage(MinecraftServer.getServer().getConfigurationManager(),
-                    String.format(outMessage, afkData.player.username));
+                    String.format(inMessage, afkData.player.username));
         }
         else
         {
-            OutputHandler.chatConfirmation(afkData.player, selfOutMessage);
+            OutputHandler.chatConfirmation(afkData.player, selfInMessage);
         }
     }
 
@@ -91,11 +91,11 @@ public class CommandAFK extends FEcmdModuleCommands {
         if (APIRegistry.perms.checkPermAllowed(new PermQueryPlayer(afkData.player, NOTICEPERM)))
         {
             ChatUtils.sendMessage(MinecraftServer.getServer().getConfigurationManager(),
-                    String.format(inMessage, afkData.player.username));
+                    String.format(outMessage, afkData.player.username));
         }
         else
         {
-            OutputHandler.chatConfirmation(afkData.player, selfInMessage);
+            OutputHandler.chatConfirmation(afkData.player, selfOutMessage);
         }
     }
 


### PR DESCRIPTION
Instead of sending "is now away", when you type "/afk" it sends "is no longer away" and when you move it sends "is now away" instead of "is no longer away"
