### PR TITLE
Cleaned up ForgeEssentials config

### DIFF
--- a/src/main/java/com/forgeessentials/backup/BackupConfig.java
+++ b/src/main/java/com/forgeessentials/backup/BackupConfig.java
@@ -41,7 +41,7 @@ public class BackupConfig extends ModuleConfigBase {
         config.addCustomCategoryComment(MAIN, "Configure the backup system.");
         backupName = config.get(MAIN, "name", "%name_%year-%month-%day_%hour-%min",
                 "The name config for the backup zip. You can use the following variables: %day, %month, %year, %hour, %min, %name").getString();
-        backupDir = config.get(MAIN, "backupsDir", "ForgeEssentials/Backups/files", "The path to the backup folder.").getString();
+        backupDir = config.get(MAIN, "backupsDir", "ForgeEssentials/Backups", "The path to the backup folder.").getString();
         backupOnWorldUnload = config.get(MAIN, "backupOnWorldUnload", true, "Make a backup when a dim unloads.").getBoolean(true);
         backupIfUnloaded = config.get(MAIN, "backupIfUnloaded", true, "Make backups if world is not loaded.").getBoolean(true);
         enableMsg = config.get(MAIN, "enableMsg", true, "Send a message to eveyone with Permission: \"ForgeEssentials.backup.msg\"").getBoolean(true);
@@ -97,7 +97,7 @@ public class BackupConfig extends ModuleConfigBase {
         config.addCustomCategoryComment(MAIN, "Configure the backup system.");
         config.get(MAIN, "name", "%name_%year-%month-%day_%hour-%min",
                 "The name config for the backup zip. You can use the following variables: %day, %month, %year, %hour, %min, %name").set(backupName);
-        config.get(MAIN, "backupsDir", "ForgeEssentials/Backups/files", "The path to the backup folder.").set(backupDir);
+        config.get(MAIN, "backupsDir", "ForgeEssentials/Backups", "The path to the backup folder.").set(backupDir);
         config.get(MAIN, "backupOnWorldUnload", true, "Make a backup when a dim unloads.").set(backupOnWorldUnload);
         config.get(MAIN, "backupIfUnloaded", true, "Make backups if world is not loaded.").set(backupIfUnloaded);
         config.get(MAIN, "enableMsg", true, "Send a message to eveyone with Permission: \"ForgeEssentials.backup.msg\"").set(enableMsg);
@@ -141,7 +141,7 @@ public class BackupConfig extends ModuleConfigBase {
         config.addCustomCategoryComment(MAIN, "Configure the backup system.");
         backupName = config.get(MAIN, "name", "%name_%year-%month-%day_%hour-%min",
                 "The name config for the backup zip. You can use the following variables: %day, %month, %year, %hour, %min, %name").getString();
-        backupDir = config.get(MAIN, "backupsDir", "ForgeEssentials/Backups/files", "The path to the backup folder.").getString();
+        backupDir = config.get(MAIN, "backupsDir", "ForgeEssentials/Backups", "The path to the backup folder.").getString();
         backupOnWorldUnload = config.get(MAIN, "backupOnWorldUnload", true, "Make a backup when a dim unloads.").getBoolean(true);
         backupIfUnloaded = config.get(MAIN, "backupIfUnloaded", true, "Make backups if world is not loaded.").getBoolean(true);
         enableMsg = config.get(MAIN, "enableMsg", true, "Send a message to eveyone with Permission: \"ForgeEssentials.backup.msg\"").getBoolean(true);

--- a/src/main/java/com/forgeessentials/backup/ModuleBackup.java
+++ b/src/main/java/com/forgeessentials/backup/ModuleBackup.java
@@ -1,14 +1,9 @@
 package com.forgeessentials.backup;
 
-import com.forgeessentials.api.APIRegistry;
-import com.forgeessentials.core.ForgeEssentials;
-import com.forgeessentials.core.moduleLauncher.FEModule;
-import com.forgeessentials.util.FunctionHelper;
-import com.forgeessentials.util.OutputHandler;
-import com.forgeessentials.util.events.FEModuleEvent.FEModuleInitEvent;
-import com.forgeessentials.util.events.FEModuleEvent.FEModuleServerInitEvent;
-import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.Timer;
+
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.management.ServerConfigurationManager;
@@ -18,12 +13,20 @@ import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.permissions.PermissionsManager;
 import net.minecraftforge.permissions.PermissionsManager.RegisteredPermValue;
 
-import java.io.File;
-import java.io.PrintWriter;
-import java.util.Timer;
+import com.forgeessentials.api.APIRegistry;
+import com.forgeessentials.core.ForgeEssentials;
+import com.forgeessentials.core.moduleLauncher.FEModule;
+import com.forgeessentials.util.FunctionHelper;
+import com.forgeessentials.util.OutputHandler;
+import com.forgeessentials.util.events.FEModuleEvent.FEModuleInitEvent;
+import com.forgeessentials.util.events.FEModuleEvent.FEModuleServerInitEvent;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 @FEModule(name = "Backups", parentMod = ForgeEssentials.class, configClass = BackupConfig.class)
 public class ModuleBackup {
+    
     @FEModule.Config
     public static BackupConfig config;
 
@@ -33,6 +36,9 @@ public class ModuleBackup {
     public static File baseFolder;
 
     private Timer timer = new Timer();
+
+    @SuppressWarnings("unused")
+    private WorldSaver worldSaver;
 
     public static void msg(String msg)
     {
@@ -70,7 +76,7 @@ public class ModuleBackup {
     public void load(FEModuleInitEvent e)
     {
         MinecraftForge.EVENT_BUS.register(this);
-        new WorldSaver();
+        worldSaver = new WorldSaver();
     }
 
     @SubscribeEvent
@@ -111,7 +117,7 @@ public class ModuleBackup {
         }
     }
 
-    private void makeReadme()
+    private static void makeReadme()
     {
         try
         {
@@ -124,21 +130,20 @@ public class ModuleBackup {
             {
                 return;
             }
-            PrintWriter pw = new PrintWriter(file);
-
-            pw.println("############");
-            pw.println("## WARNING ##");
-            pw.println("############");
-            pw.println("");
-            pw.println("DON'T CHANGE ANYTHING IN THIS FOLDER.");
-            pw.println("IF YOU DO, AUTOREMOVE WILL SCREW UP.");
-            pw.println("");
-            pw.println("If you have problems with this, report an issue and don't put:");
-            pw.println("\"Yes, I read the readme\" in the issue or your message on github,");
-            pw.println("YOU WILL BE IGNORED.");
-            pw.println("- The FE Team");
-
-            pw.close();
+            try (PrintWriter pw = new PrintWriter(file))
+            {
+                pw.println("############");
+                pw.println("## WARNING ##");
+                pw.println("############");
+                pw.println("");
+                pw.println("DON'T CHANGE ANYTHING IN THIS FOLDER.");
+                pw.println("IF YOU DO, AUTOREMOVE WILL SCREW UP.");
+                pw.println("");
+                pw.println("If you have problems with this, report an issue and don't put:");
+                pw.println("\"Yes, I read the readme\" in the issue or your message on github,");
+                pw.println("YOU WILL BE IGNORED.");
+                pw.println("- The FE Team");
+            }
         }
         catch (Exception e)
         {

--- a/src/main/java/com/forgeessentials/chat/ModuleChat.java
+++ b/src/main/java/com/forgeessentials/chat/ModuleChat.java
@@ -1,5 +1,16 @@
 package com.forgeessentials.chat;
 
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.Map;
+import java.util.Set;
+
+import net.minecraft.command.CommandHandler;
+import net.minecraft.command.ICommand;
+import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.permissions.PermissionsManager.RegisteredPermValue;
+
 import com.forgeessentials.api.APIRegistry;
 import com.forgeessentials.chat.commands.CommandAutoMessage;
 import com.forgeessentials.chat.commands.CommandMail;
@@ -22,22 +33,14 @@ import com.forgeessentials.util.events.FEModuleEvent.FEModulePostInitEvent;
 import com.forgeessentials.util.events.FEModuleEvent.FEModuleServerInitEvent;
 import com.forgeessentials.util.events.FEModuleEvent.FEModuleServerPostInitEvent;
 import com.forgeessentials.util.events.FEModuleEvent.FEModuleServerStopEvent;
+
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.relauncher.ReflectionHelper;
-import net.minecraft.command.CommandHandler;
-import net.minecraft.command.ICommand;
-import net.minecraft.server.MinecraftServer;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.permissions.PermissionsManager.RegisteredPermValue;
-
-import java.io.File;
-import java.io.PrintWriter;
-import java.util.Map;
-import java.util.Set;
 
 @FEModule(name = "Chat", parentMod = ForgeEssentials.class, configClass = ConfigChat.class)
 public class ModuleChat {
+    
     @FEModule.Config
     public static ConfigChat conf;
 
@@ -45,11 +48,19 @@ public class ModuleChat {
     public static File moduleDir;
 
     public static PrintWriter chatLog;
+    
     public static PrintWriter cmdLog;
+    
     public static File logdir;
+    
     public static boolean connectToIRC;
+    
     private MailSystem mailsystem;
+    
     private PlayerEventHandler ircPlayerHandler;
+
+    @SuppressWarnings("unused")
+    private AutoMessage autoMessage;
 
     @SubscribeEvent
     public void load(FEModuleInitEvent e)
@@ -88,7 +99,7 @@ public class ModuleChat {
 
         try
         {
-            logdir = new File(moduleDir, "logs/");
+            logdir = moduleDir;
             logdir.mkdirs();
         }
         catch (Exception e1)
@@ -131,7 +142,7 @@ public class ModuleChat {
     public void serverStarted(FEModuleServerPostInitEvent e)
     {
         removeTell(FMLCommonHandler.instance().getMinecraftServerInstance());
-        new AutoMessage(FMLCommonHandler.instance().getMinecraftServerInstance());
+        autoMessage = new AutoMessage(FMLCommonHandler.instance().getMinecraftServerInstance());
         MailSystem.LoadAll();
         FMLCommonHandler.instance().bus().register(mailsystem);
         if (connectToIRC)
@@ -153,7 +164,7 @@ public class ModuleChat {
         }
     }
 
-    private void removeTell(MinecraftServer server)
+    private static void removeTell(MinecraftServer server)
     {
         if (server.getCommandManager() instanceof CommandHandler)
         {
@@ -187,7 +198,7 @@ public class ModuleChat {
                         }
                     }
                 }
-                if (toRemove != null)
+                if (cmdClass != null && toRemove != null)
                 {
                     OutputHandler.felog.finer("Removing command '" + toRemove.getCommandName() + "' from class: " + cmdClass.getName());
                     cmdList.remove(toRemove);

--- a/src/main/java/com/forgeessentials/commands/ModuleCommands.java
+++ b/src/main/java/com/forgeessentials/commands/ModuleCommands.java
@@ -1,5 +1,9 @@
 package com.forgeessentials.commands;
 
+import net.minecraft.command.ICommandSender;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.permissions.PermissionsManager.RegisteredPermValue;
+
 import com.forgeessentials.api.APIRegistry;
 import com.forgeessentials.commands.network.S5PacketNoclip;
 import com.forgeessentials.commands.shortcut.ShortcutCommands;
@@ -15,23 +19,17 @@ import com.forgeessentials.util.events.FEModuleEvent.FEModuleInitEvent;
 import com.forgeessentials.util.events.FEModuleEvent.FEModulePreInitEvent;
 import com.forgeessentials.util.events.FEModuleEvent.FEModuleServerInitEvent;
 import com.forgeessentials.util.events.FEModuleEvent.FEModuleServerStopEvent;
+
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.relauncher.Side;
-import net.minecraft.command.ICommandSender;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.permissions.PermissionsManager.RegisteredPermValue;
 
-import java.io.File;
-
-@FEModule(configClass = ConfigCmd.class, name = "CommandsModule", parentMod = ForgeEssentials.class)
+@FEModule(configClass = ConfigCmd.class, name = "Commands", parentMod = ForgeEssentials.class)
 public class ModuleCommands {
+    
     @FEModule.Config
     public static ConfigCmd conf;
-
-    @FEModule.ModuleDir
-    public static File cmddir;
 
     public static CommandsEventHandler eventHandler = new CommandsEventHandler();
 
@@ -48,7 +46,7 @@ public class ModuleCommands {
     public void load(FEModuleInitEvent e)
     {
         CommandRegistrar.commandConfigs(conf.getConfig());
-        ShortcutCommands.loadConfig(cmddir);
+        ShortcutCommands.loadConfig(ForgeEssentials.FEDIR);
     }
 
     @SubscribeEvent

--- a/src/main/java/com/forgeessentials/commands/shortcut/ShortcutCommands.java
+++ b/src/main/java/com/forgeessentials/commands/shortcut/ShortcutCommands.java
@@ -19,6 +19,7 @@ import net.minecraftforge.common.config.Configuration;
  * @author Dries007
  */
 public class ShortcutCommands {
+
     private static final String ARGS_COMMENT =
             "The argumtens to be send to the command. Use double quotes.\n" +
                     "Usable variables:\n" +
@@ -28,7 +29,9 @@ public class ShortcutCommands {
                     "$oArg => the next argument, but optional. If there is no argument, doesn't do anything.";
 
     static ArrayList<CommandWrapper> list = new ArrayList<CommandWrapper>();
+
     static HashMap<String, CommandWrapper> cmdMap = new HashMap<String, CommandWrapper>();
+
     static Configuration config;
 
     /**
@@ -52,7 +55,7 @@ public class ShortcutCommands {
      */
     public static void loadConfig(File folder)
     {
-        File confFile = new File(folder, "shortcuts.cfg");
+        File confFile = new File(folder, "CommandShortcuts.cfg");
         config = new Configuration(confFile);
         parseConfig();
     }

--- a/src/main/java/com/forgeessentials/commands/util/ConfigCmd.java
+++ b/src/main/java/com/forgeessentials/commands/util/ConfigCmd.java
@@ -2,8 +2,6 @@ package com.forgeessentials.commands.util;
 
 import net.minecraft.command.ICommandSender;
 
-import com.forgeessentials.commands.CommandRules;
-import com.forgeessentials.commands.ModuleCommands;
 import com.forgeessentials.core.moduleLauncher.ModuleConfigBase;
 
 public class ConfigCmd extends ModuleConfigBase {
@@ -19,10 +17,6 @@ public class ConfigCmd extends ModuleConfigBase {
     @Override
     public void forceSave()
     {
-        // TODO: may have problems..
-        String path = CommandRules.rulesFile.getPath();
-        path = path.replace(ModuleCommands.cmddir.getPath(), "");
-
         config.addCustomCategoryComment("general", "General Commands configuration.");
         config.save();
     }

--- a/src/main/java/com/forgeessentials/core/moduleLauncher/ModuleLauncher.java
+++ b/src/main/java/com/forgeessentials/core/moduleLauncher/ModuleLauncher.java
@@ -1,22 +1,24 @@
 package com.forgeessentials.core.moduleLauncher;
 
+import java.io.File;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import net.minecraft.command.ICommandSender;
+
 import com.forgeessentials.api.APIRegistry.ForgeEssentialsRegistrar;
 import com.forgeessentials.core.ForgeEssentials;
 import com.forgeessentials.core.misc.CoreConfig;
 import com.forgeessentials.util.FunctionHelper;
 import com.forgeessentials.util.OutputHandler;
 import com.forgeessentials.util.events.FEModuleEvent.FEModulePreInitEvent;
+
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.ModContainer;
 import cpw.mods.fml.common.discovery.ASMDataTable.ASMData;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import net.minecraft.command.ICommandSender;
-
-import java.io.File;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
 
 public class ModuleLauncher {
     public ModuleLauncher()
@@ -134,7 +136,7 @@ public class ModuleLauncher {
                 }
                 else
                 {
-                    cfg.setFile(new File(ForgeEssentials.FEDIR, module.name + "/config.cfg"));
+                    cfg.setFile(new File(ForgeEssentials.FEDIR, module.name + ".cfg"));
                 }
 
                 File file = cfg.getFile();

--- a/src/main/java/com/forgeessentials/economy/ModuleEconomy.java
+++ b/src/main/java/com/forgeessentials/economy/ModuleEconomy.java
@@ -22,11 +22,10 @@ import com.forgeessentials.util.events.FEModuleEvent.FEModuleInitEvent;
 import com.forgeessentials.util.events.FEModuleEvent.FEModulePreInitEvent;
 import com.forgeessentials.util.events.FEModuleEvent.FEModuleServerInitEvent;
 import com.forgeessentials.util.events.FEModuleEvent.FEModuleServerStopEvent;
+
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.relauncher.Side;
-
-import java.io.File;
 
 /**
  * Call the WalletHandler class when working with Economy
@@ -35,9 +34,6 @@ import java.io.File;
 public class ModuleEconomy {
     @FEModule.Config
     public static ConfigEconomy config;
-
-    @FEModule.ModuleDir
-    public static File moduleDir;
 
     public static int startbudget;
 

--- a/src/main/java/com/forgeessentials/scripting/ModuleScripting.java
+++ b/src/main/java/com/forgeessentials/scripting/ModuleScripting.java
@@ -1,16 +1,17 @@
 package com.forgeessentials.scripting;
 
+import java.io.File;
+
 import com.forgeessentials.core.ForgeEssentials;
 import com.forgeessentials.core.moduleLauncher.FEModule;
 import com.forgeessentials.util.FunctionHelper;
 import com.forgeessentials.util.OutputHandler;
 import com.forgeessentials.util.events.FEModuleEvent.FEModulePreInitEvent;
 import com.forgeessentials.util.events.FEModuleEvent.FEModuleServerInitEvent;
+
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
-import java.io.File;
-
-@FEModule(name = "scripting", parentMod = ForgeEssentials.class, isCore = false)
+@FEModule(name = "Scripting", parentMod = ForgeEssentials.class, isCore = false)
 public class ModuleScripting {
 
     @FEModule.ModuleDir

--- a/src/main/java/com/forgeessentials/servervote/ModuleServerVote.java
+++ b/src/main/java/com/forgeessentials/servervote/ModuleServerVote.java
@@ -1,5 +1,16 @@
 package com.forgeessentials.servervote;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.PrintWriter;
+import java.util.HashMap;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.play.server.S02PacketChat;
+import net.minecraftforge.common.MinecraftForge;
+
 import com.forgeessentials.core.ForgeEssentials;
 import com.forgeessentials.core.moduleLauncher.FEModule;
 import com.forgeessentials.core.moduleLauncher.FEModule.Config;
@@ -10,23 +21,14 @@ import com.forgeessentials.util.OutputHandler;
 import com.forgeessentials.util.events.FEModuleEvent.FEModuleInitEvent;
 import com.forgeessentials.util.events.FEModuleEvent.FEModuleServerInitEvent;
 import com.forgeessentials.util.events.FEModuleEvent.FEModuleServerStopEvent;
+
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.item.ItemStack;
-import net.minecraft.network.play.server.S02PacketChat;
-import net.minecraftforge.common.MinecraftForge;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.PrintWriter;
-import java.util.HashMap;
-
-@FEModule(name = "ServerVoteModule", parentMod = ForgeEssentials.class, configClass = ConfigServerVote.class)
+@FEModule(name = "ServerVote", parentMod = ForgeEssentials.class, configClass = ConfigServerVote.class)
 public class ModuleServerVote {
     @Config
     public static ConfigServerVote config;

--- a/src/main/java/com/forgeessentials/snooper/ModuleSnooper.java
+++ b/src/main/java/com/forgeessentials/snooper/ModuleSnooper.java
@@ -24,19 +24,24 @@ import com.forgeessentials.util.events.FEModuleEvent.FEModuleServerStopEvent;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
-@FEModule(name = "SnooperModule", parentMod = ForgeEssentials.class, configClass = ConfigSnooper.class)
+@FEModule(name = "Snooper", parentMod = ForgeEssentials.class, configClass = ConfigSnooper.class)
 public class ModuleSnooper {
+
     @FEModule.Config
     public static ConfigSnooper configSnooper;
-    public static int port;
-    public static String hostname;
-    public static boolean enable;
-    public static SocketListner socketListner;
-    public static String key;
-    private static int id = 0;
-    @FEModule.ModuleDir
-    public File folder;
 
+    public static int port;
+    
+    public static String hostname;
+    
+    public static boolean enable;
+    
+    public static SocketListner socketListner;
+    
+    public static String key;
+    
+    private static int id = 0;
+    
     public ModuleSnooper()
     {
         MinecraftForge.EVENT_BUS.register(this);
@@ -69,7 +74,7 @@ public class ModuleSnooper {
     {
         if (!enable)
         {
-            ModuleLauncher.instance.unregister("SnooperModule");
+            ModuleLauncher.instance.unregister("Snooper");
         }
     }
 
@@ -81,11 +86,11 @@ public class ModuleSnooper {
         start();
     }
 
-    private void getKey()
+    private static void getKey()
     {
         try
         {
-            File file = new File(folder, "key.key");
+            File file = new File(ForgeEssentials.FEDIR, "snooper.key");
             if (file.exists())
             {
                 try (FileInputStream in = new FileInputStream(file))

--- a/src/main/java/com/forgeessentials/teleport/TeleportModule.java
+++ b/src/main/java/com/forgeessentials/teleport/TeleportModule.java
@@ -28,7 +28,7 @@ import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
 
-@FEModule(name = "TeleportModule", parentMod = ForgeEssentials.class)
+@FEModule(name = "Teleport", parentMod = ForgeEssentials.class)
 public class TeleportModule {
 
     public static final String PERM_TP = "fe.teleport.tp";

--- a/src/main/java/com/forgeessentials/tickets/ModuleTickets.java
+++ b/src/main/java/com/forgeessentials/tickets/ModuleTickets.java
@@ -1,5 +1,12 @@
 package com.forgeessentials.tickets;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraftforge.permissions.PermissionsManager;
+import net.minecraftforge.permissions.PermissionsManager.RegisteredPermValue;
+
 import com.forgeessentials.api.APIRegistry;
 import com.forgeessentials.core.ForgeEssentials;
 import com.forgeessentials.core.moduleLauncher.FEModule;
@@ -10,25 +17,21 @@ import com.forgeessentials.util.OutputHandler;
 import com.forgeessentials.util.events.FEModuleEvent.FEModuleInitEvent;
 import com.forgeessentials.util.events.FEModuleEvent.FEModuleServerInitEvent;
 import com.forgeessentials.util.events.FEModuleEvent.FEModuleServerStopEvent;
+
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
-import net.minecraft.util.EnumChatFormatting;
-import net.minecraftforge.permissions.PermissionsManager;
-import net.minecraftforge.permissions.PermissionsManager.RegisteredPermValue;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 
 @FEModule(name = "Tickets", parentMod = ForgeEssentials.class, configClass = ConfigTickets.class)
 public class ModuleTickets {
+
     public static final String PERMBASE = "fe.tickets";
+    
     @FEModule.Config
     public static ConfigTickets config;
-    @FEModule.ModuleDir
-    public static File moduleDir;
+    
     public static ArrayList<Ticket> ticketList = new ArrayList<Ticket>();
+    
     public static List<String> categories = new ArrayList<String>();
 
     public static int currentID;


### PR DESCRIPTION
This is a cleanup of the FE config directory, which creates way to many directories, of which many only contain one single config file.
This change puts them all in the `ForgeEssentials` directory with a name according to the module (i.e. _Chat_ module config is stored in `Chat.cfg`)
