### PR TITLE
[worldborder] Fixed check if chunk exists bug

### DIFF
--- a/src/main/java/com/forgeessentials/worldborder/TickTaskFill.java
+++ b/src/main/java/com/forgeessentials/worldborder/TickTaskFill.java
@@ -186,8 +186,8 @@ public class TickTaskFill implements ITickTask
 			 * skip over chunks that already exist (we use the region cache so
 			 * as to not load them)
 			 */
-			while (!RegionFileCache.createOrLoadRegionFile(
-					world.getChunkSaveLocation(), X >> 5, Z >> 5).chunkExists(
+			while (RegionFileCache.createOrLoadRegionFile(
+					world.getChunkSaveLocation(), X, Z).chunkExists(
 					X & 0x1F, Z & 0x1F))
 			{
 				--todo;


### PR DESCRIPTION
createOrLoadRegionFile takes chunk coordinates, not region coordinates
as the function name would suggest. This is a major bug that causes
existing chunks in the world to get re-generated and overwritten.
