### PR TITLE
Check permission for both dimensions on cross-dimensional teleport and deny if either check fails

### DIFF
--- a/src/main/java/com/forgeessentials/core/ForgeEssentials.java
+++ b/src/main/java/com/forgeessentials/core/ForgeEssentials.java
@@ -365,7 +365,8 @@ public class ForgeEssentials extends ConfigLoaderBase
         APIRegistry.perms.registerPermissionProperty(TeleportHelper.TELEPORT_WARMUP, "3", "Allow bypassing teleport warmup");
         APIRegistry.perms.registerPermissionPropertyOp(TeleportHelper.TELEPORT_COOLDOWN, "0");
         APIRegistry.perms.registerPermissionPropertyOp(TeleportHelper.TELEPORT_WARMUP, "0");
-        APIRegistry.perms.registerPermission(TeleportHelper.TELEPORT_CROSSDIM, PermissionLevel.TRUE, "Allow teleporting across dimensions");
+        APIRegistry.perms.registerPermission(TeleportHelper.TELEPORT_CROSSDIM_FROM, PermissionLevel.TRUE, "Allow teleporting cross-dimensionally from a dimension");
+        APIRegistry.perms.registerPermission(TeleportHelper.TELEPORT_CROSSDIM_TO, PermissionLevel.TRUE, "Allow teleporting cross-dimensionally to a dimension");
         APIRegistry.perms.registerPermission(TeleportHelper.TELEPORT_FROM, PermissionLevel.TRUE, "Allow being teleported from a certain location / dimension");
         APIRegistry.perms.registerPermission(TeleportHelper.TELEPORT_TO, PermissionLevel.TRUE, "Allow being teleported to a certain location / dimension");
 

--- a/src/main/java/com/forgeessentials/core/misc/TeleportHelper.java
+++ b/src/main/java/com/forgeessentials/core/misc/TeleportHelper.java
@@ -129,7 +129,7 @@ public class TeleportHelper extends ServerEventHandler
             throw new TranslatedCommandException("You are not allowed to teleport from here.");
         if (!APIRegistry.perms.checkUserPermission(ident, point.toWorldPoint(), TELEPORT_TO))
             throw new TranslatedCommandException("You are not allowed to teleport to that location.");
-        if (player.dimension != point.getDimension() && !APIRegistry.perms.checkUserPermission(ident, point.toWorldPoint(), TELEPORT_CROSSDIM))
+        if (player.dimension != point.getDimension() && (!APIRegistry.perms.checkPermission(player, TELEPORT_CROSSDIM) || !APIRegistry.perms.checkUserPermission(ident, point.toWorldPoint(), TELEPORT_CROSSDIM)))
             throw new TranslatedCommandException("You are not allowed to teleport across dimensions.");
 
         // Get and check teleport cooldown

--- a/src/main/java/com/forgeessentials/core/misc/TeleportHelper.java
+++ b/src/main/java/com/forgeessentials/core/misc/TeleportHelper.java
@@ -105,7 +105,8 @@ public class TeleportHelper extends ServerEventHandler
 
     public static final String TELEPORT_COOLDOWN = "fe.teleport.cooldown";
     public static final String TELEPORT_WARMUP = "fe.teleport.warmup";
-    public static final String TELEPORT_CROSSDIM = "fe.teleport.crossdim";
+    public static final String TELEPORT_CROSSDIM_FROM = "fe.teleport.crossdim.from";
+    public static final String TELEPORT_CROSSDIM_TO = "fe.teleport.crossdim.to";
     public static final String TELEPORT_FROM = "fe.teleport.from";
     public static final String TELEPORT_TO = "fe.teleport.to";
 
@@ -129,8 +130,12 @@ public class TeleportHelper extends ServerEventHandler
             throw new TranslatedCommandException("You are not allowed to teleport from here.");
         if (!APIRegistry.perms.checkUserPermission(ident, point.toWorldPoint(), TELEPORT_TO))
             throw new TranslatedCommandException("You are not allowed to teleport to that location.");
-        if (player.dimension != point.getDimension() && (!APIRegistry.perms.checkPermission(player, TELEPORT_CROSSDIM) || !APIRegistry.perms.checkUserPermission(ident, point.toWorldPoint(), TELEPORT_CROSSDIM)))
-            throw new TranslatedCommandException("You are not allowed to teleport across dimensions.");
+        if (player.dimension != point.getDimension()) {
+            if (!APIRegistry.perms.checkPermission(player, TELEPORT_CROSSDIM_FROM))
+                throw new TranslatedCommandException("You are not allowed to teleport from this dimension.");
+            if (!APIRegistry.perms.checkUserPermission(ident, point.toWorldPoint(), TELEPORT_CROSSDIM_TO))
+                throw new TranslatedCommandException("You are not allowed to teleport to that dimension.");
+        }
 
         // Get and check teleport cooldown
         int teleportCooldown = ServerUtil.parseIntDefault(APIRegistry.perms.getUserPermissionProperty(ident, TELEPORT_COOLDOWN), 0) * 1000;


### PR DESCRIPTION
This should allow you to prevent teleporting to *or* from a dimension. Simple solution, though I think a better one would be to create a crossdim permission for each and every dimension, that way you could deny teleporting between any specific set of dimensions.