### PR TITLE
Fixed breaking protected blocks when standing outside of zone/plot. F…

### DIFF
--- a/src/main/java/com/forgeessentials/api/permissions/AreaZone.java
+++ b/src/main/java/com/forgeessentials/api/permissions/AreaZone.java
@@ -44,7 +44,7 @@ public class AreaZone extends Zone implements Comparable<AreaZone>
     public AreaZone(WorldZone worldZone, String name, AreaBase area) throws EventCancelledException
     {
         // Initialize basic AreaZone data
-        this(worldZone.getServerZone().getMaxZoneID() + 1);
+        this(0);
         this.worldZone = worldZone;
         this.name = name;
         this.area = area;
@@ -53,7 +53,7 @@ public class AreaZone extends Zone implements Comparable<AreaZone>
         EventCancelledException.checkedPost(new PermissionEvent.Zone.Create(worldZone.getServerZone(), this), APIRegistry.getFEEventBus());
 
         // If not cancelled, inc the zoneID pointer and add the zone to the world
-        worldZone.getServerZone().nextZoneID();
+        this.setId(worldZone.nextAreaZoneId());
         this.worldZone.addAreaZone(this);
     }
 

--- a/src/main/java/com/forgeessentials/api/permissions/ServerZone.java
+++ b/src/main/java/com/forgeessentials/api/permissions/ServerZone.java
@@ -512,6 +512,23 @@ public class ServerZone extends Zone implements Loadable
         List<AreaZone> zones = getAreaZonesAt(worldPoint);
         return zones.isEmpty() ? null : zones.get(0);
     }
+    
+    public AreaZone getAreaZone(int zoneId)
+    {
+        for (Map.Entry<Integer, WorldZone> worldEntry : getServerZone().getWorldZones().entrySet())
+        {
+            WorldZone wZone = worldEntry.getValue();
+            if (wZone != null)
+            {
+                AreaZone aZone = wZone.getAreaZone(zoneId);
+                if (aZone != null)
+                {
+                    return aZone;
+                }
+            }
+        }
+        return null;
+    }
 
     // ------------------------------------------------------------
 

--- a/src/main/java/com/forgeessentials/api/permissions/WorldZone.java
+++ b/src/main/java/com/forgeessentials/api/permissions/WorldZone.java
@@ -51,6 +51,29 @@ public class WorldZone extends Zone implements Loadable
             zone.worldZone = this;
     }
     
+    public AreaZone getAreaZone(int id)
+    {
+        for (AreaZone zone : getAreaZones())
+        {
+            if (zone.getId() == id)
+            {
+                return zone;
+            }
+        }
+        return null;
+    }
+
+    public int nextAreaZoneId()
+    {
+        int desiredID = getServerZone().getMaxZoneID() + 1;
+        while (desiredID < 5 || getServerZone().getAreaZone(desiredID) != null)
+        {
+            getServerZone().nextZoneID();
+            desiredID = getServerZone().getMaxZoneID() + 1;
+        }
+        return desiredID;
+    }
+    
     @Override
     public boolean isPlayerInZone(EntityPlayer player)
     {

--- a/src/main/java/com/forgeessentials/api/permissions/WorldZone.java
+++ b/src/main/java/com/forgeessentials/api/permissions/WorldZone.java
@@ -23,6 +23,8 @@ public class WorldZone extends Zone implements Loadable
     protected ServerZone serverZone;
 
     private int dimensionID;
+    
+    private static final int RESERVED_ID_COUNT = 5;
 
     private List<AreaZone> areaZones = new ArrayList<AreaZone>();
 
@@ -66,7 +68,7 @@ public class WorldZone extends Zone implements Loadable
     public int nextAreaZoneId()
     {
         int desiredID = getServerZone().getMaxZoneID() + 1;
-        while (desiredID < 5 || getServerZone().getAreaZone(desiredID) != null)
+        while (desiredID < RESERVED_ID_COUNT || getServerZone().getAreaZone(desiredID) != null)
         {
             getServerZone().nextZoneID();
             desiredID = getServerZone().getMaxZoneID() + 1;

--- a/src/main/java/com/forgeessentials/api/permissions/Zone.java
+++ b/src/main/java/com/forgeessentials/api/permissions/Zone.java
@@ -168,6 +168,11 @@ public abstract class Zone
         this.id = id;
     }
 
+    public void setId(int id)
+    {
+        this.id = id;
+    }
+    
     /**
      * Gets the unique zone-ID
      */

--- a/src/main/java/com/forgeessentials/protection/ProtectionEventHandler.java
+++ b/src/main/java/com/forgeessentials/protection/ProtectionEventHandler.java
@@ -250,7 +250,8 @@ public class ProtectionEventHandler extends ServerEventHandler
         IBlockState blockState = event.getWorld().getBlockState(event.getPos());
         String permission = ModuleProtection.getBlockBreakPermission(blockState);
         ModuleProtection.debugPermission(event.getPlayer(), permission);
-        if (!APIRegistry.perms.checkUserPermission(ident, permission))
+        WorldPoint point = new WorldPoint(event.getPlayer().dimension, event.getPos());
+        if (!APIRegistry.perms.checkUserPermission(ident, point, permission))
         {
             event.setCanceled(true);
             TileEntity te = event.getWorld().getTileEntity(event.getPos());
@@ -463,6 +464,18 @@ public class ProtectionEventHandler extends ServerEventHandler
             ModuleProtection.debugPermission(event.getEntityPlayer(), permission);
             boolean allow = APIRegistry.perms.checkUserPermission(ident, point, permission);
             // event.useItem = allow ? ALLOW : DENY;
+            if (event instanceof LeftClickBlock)
+            {
+                ((LeftClickBlock) event).setUseItem(allow ? ALLOW : DENY);
+            }
+            else if (event instanceof RightClickBlock)
+            {
+                ((RightClickBlock) event).setUseItem(allow ? ALLOW : DENY);
+            }
+            else if (!allow && !event.isCanceled() && event.isCancelable())
+            {
+                event.setCanceled(true);
+            }
             if (!allow && PlayerInfo.get(ident).getHasFEClient())
             {
                 int itemId = Item.REGISTRY.getIDForObject(stack.getItem());

--- a/src/main/java/com/forgeessentials/protection/ProtectionEventHandler.java
+++ b/src/main/java/com/forgeessentials/protection/ProtectionEventHandler.java
@@ -367,7 +367,7 @@ public class ProtectionEventHandler extends ServerEventHandler
         int cx = (int) Math.floor(center.x);
         int cy = (int) Math.floor(center.y);
         int cz = (int) Math.floor(center.z);
-        float size = ReflectionHelper.getPrivateValue(Explosion.class, event.getExplosion(), "field_77280_f", "explosionSize");
+        float size = ReflectionHelper.getPrivateValue(Explosion.class, event.getExplosion(), "size", "field_77280_f");
         int s = (int) Math.ceil(size);
 
         if (!APIRegistry.perms.checkUserPermission(ident, new WorldPoint(event.getWorld(), cx, cy, cz), ModuleProtection.PERM_EXPLOSION))


### PR DESCRIPTION
Fixes three bugs.
1) Blocks can be broken within a zone when the player is standing outside of the zone.
2) Zones can be overwritten due to id collisions when defining a zone/plot.
3) Explosions causing crashes.