### PR TITLE
Sync inventory with server side after sell items to shop

### DIFF
--- a/src/main/java/com/forgeessentials/economy/ModuleEconomy.java
+++ b/src/main/java/com/forgeessentials/economy/ModuleEconomy.java
@@ -177,25 +177,28 @@ public class ModuleEconomy extends ServerEventHandler implements Economy, Config
 
     public static int tryRemoveItems(EntityPlayer player, ItemStack itemStack, int amount)
     {
-        int foundStacks = 0;
         int itemDamage = ItemUtil.getItemDamage(itemStack);
-        for (int slot = 0; slot < player.inventory.mainInventory.length; slot++)
+
+        for (int slot = 0; slot < player.inventory.mainInventory.length && amount > 0; slot++)
         {
             ItemStack stack = player.inventory.mainInventory[slot];
-            if (stack != null && stack.getItem() == itemStack.getItem() && (itemDamage == -1 || stack.getItemDamage() == itemDamage))
-                foundStacks += stack.stackSize;
-        }
-        foundStacks = amount = Math.min(foundStacks, amount);
-        for (int slot = 0; slot < player.inventory.mainInventory.length; slot++)
-        {
-            ItemStack stack = player.inventory.mainInventory[slot];
+
             if (stack != null && stack.getItem() == itemStack.getItem() && (itemDamage == -1 || stack.getItemDamage() == itemDamage))
             {
-                int removeCount = Math.min(stack.stackSize, foundStacks);
-                player.inventory.decrStackSize(slot, removeCount);
-                foundStacks -= removeCount;
+                int removeCount = Math.min(stack.stackSize, amount);
+
+                if (removeCount == stack.stackSize) {
+                    player.inventory.setInventorySlotContents(slot, null);
+                } else {
+                    player.inventory.decrStackSize(slot, removeCount);
+                }
+
+                amount -= removeCount;
             }
         }
+
+        player.inventoryContainer.detectAndSendChanges();
+
         return amount;
     }
 

--- a/src/main/java/com/forgeessentials/economy/shop/ShopManager.java
+++ b/src/main/java/com/forgeessentials/economy/shop/ShopManager.java
@@ -305,7 +305,9 @@ public class ShopManager extends ServerEventHandler implements ConfigLoader
                 ChatOutputHandler.sendMessage(event.entityPlayer, msg);
                 return;
             }
+
             int removedAmount = 0;
+
             if (sameItem)
             {
                 removedAmount = Math.min(equippedStack.stackSize, transactionStack.stackSize);
@@ -313,8 +315,11 @@ public class ShopManager extends ServerEventHandler implements ConfigLoader
                 if (equippedStack.stackSize <= 0)
                     event.entityPlayer.inventory.mainInventory[event.entityPlayer.inventory.currentItem] = null;
             }
-            if (removedAmount < transactionStack.stackSize)
-                removedAmount += ModuleEconomy.tryRemoveItems(event.entityPlayer, transactionStack, transactionStack.stackSize - removedAmount);
+
+            if (removedAmount < transactionStack.stackSize) {
+                ModuleEconomy.tryRemoveItems(event.entityPlayer, transactionStack, transactionStack.stackSize - removedAmount);
+            }
+
             wallet.add(shop.sellPrice);
             shop.setStock(shop.getStock() + 1);
 


### PR DESCRIPTION
Fixed: If the mod is installed only on the server side, sold items not removed from the player’s inventory in case items not enough in a hand.