### PR TITLE
Fix #2453: Use ItemStack.EMPTY for empty slot in virtualchest

### DIFF
--- a/src/main/java/com/forgeessentials/commands/util/VirtualChest.java
+++ b/src/main/java/com/forgeessentials/commands/util/VirtualChest.java
@@ -47,7 +47,7 @@ public class VirtualChest extends InventoryBasic
     public void loadInventoryFromNBT(NBTTagList tag)
     {
         for (int slotIndex = 0; slotIndex < getSizeInventory(); ++slotIndex)
-            setInventorySlotContents(slotIndex, (ItemStack) null);
+            setInventorySlotContents(slotIndex, ItemStack.EMPTY);
         for (int tagIndex = 0; tagIndex < tag.tagCount(); ++tagIndex)
         {
             NBTTagCompound tagSlot = tag.getCompoundTagAt(tagIndex);


### PR DESCRIPTION
I fixed (and tested) the issue I opened 4 hours ago: #2453