### PR TITLE
Change setspawn command name to fesetspawn, add setspawn as an alias

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 
 # Tell Travis this is a Java project.
 language: java
-
+dist: trusty
 jdk:
   - oraclejdk8
 

--- a/src/main/java/com/forgeessentials/teleport/CommandSetSpawn.java
+++ b/src/main/java/com/forgeessentials/teleport/CommandSetSpawn.java
@@ -22,7 +22,13 @@ public class CommandSetSpawn extends ParserCommandBase
     @Override
     public String getName()
     {
-        return "setspawn";
+        return "fesetspawn";
+    }
+    
+    @Override
+    public String[] getDefaultAliases()
+    {
+        return new String[] { "setspawn" };
     }
 
     @Override


### PR DESCRIPTION
Enables compatibility with other mods that use /setspawn without having to disable the teleport module.