### PR TITLE
CraftingManager Mixin Comparability Fix

### DIFF
--- a/src/main/java/com/forgeessentials/core/preloader/mixin/item/crafting/MixinCraftingManager.java
+++ b/src/main/java/com/forgeessentials/core/preloader/mixin/item/crafting/MixinCraftingManager.java
@@ -30,31 +30,19 @@ public abstract class MixinCraftingManager
      * @param cir the callback info
      */
     @Inject(
-        method = "findMatchingRecipe",
-        at = @At(
-            value = "INVOKE",
-            target = "Ljava/util/List;size()I",
-            shift = At.Shift.BEFORE
-        ),
-        cancellable = true
-    )
+            method = "findMatchingRecipe",
+            at = @At("RETURN"),
+            cancellable = true
+        )
     private void findCraftingResultPermissible(InventoryCrafting inventory, World world, CallbackInfoReturnable<ItemStack> cir)
     {
         EntityPlayer player = ModuleProtection.getCraftingPlayer(inventory);
-        for (IRecipe recipe : this.recipes)
+        ItemStack result = cir.getReturnValue();
+        if (result == null || player == null || ModuleProtection.canCraft(player, result))
         {
-            if (recipe.matches(inventory, world))
-            {
-                ItemStack result = recipe.getCraftingResult(inventory);
-                if (player == null || ModuleProtection.canCraft(player, result))
-                {
-                    cir.setReturnValue(result);
-                    return;
-                }
-            }
+            return;
         }
 
         cir.setReturnValue(null);
     }
-
 }

--- a/src/main/java/com/forgeessentials/core/preloader/mixin/item/crafting/MixinCraftingManager.java
+++ b/src/main/java/com/forgeessentials/core/preloader/mixin/item/crafting/MixinCraftingManager.java
@@ -36,9 +36,13 @@ public abstract class MixinCraftingManager
         )
     private void findCraftingResultPermissible(InventoryCrafting inventory, World world, CallbackInfoReturnable<ItemStack> cir)
     {
+    	ItemStack result = cir.getReturnValue();
+    	if (result == null) {
+    		return;
+    	}
+    	
         EntityPlayer player = ModuleProtection.getCraftingPlayer(inventory);
-        ItemStack result = cir.getReturnValue();
-        if (result == null || player == null || ModuleProtection.canCraft(player, result))
+        if (player == null || ModuleProtection.canCraft(player, result))
         {
             return;
         }


### PR DESCRIPTION
I know this is for an older so if y'all do not want to merge it due to being outdated I am ok with that. 
This is a fix for #2108 

I changed the mixin that is used to check if a player is allowed to craft a recipe to run when `findMatchingRecipe()` returns instead of at the specified point. While this bug is likely due to an issue in ExtraUtils, this fix will also allow for better compatibility and ever so slightly better performance.
There is better performance with this because it does not have to find the recipe twice as it takes the return value and uses that as the result.