### PR TITLE
add option `loadOnServerStart` to `Multiworld`

### DIFF
--- a/src/main/java/com/forgeessentials/multiworld/Multiworld.java
+++ b/src/main/java/com/forgeessentials/multiworld/Multiworld.java
@@ -45,6 +45,8 @@ public class Multiworld
 
     protected boolean mapFeaturesEnabled = true;
 
+    protected boolean loadOnServerStart = true;
+
     @Expose(serialize = false)
     protected boolean worldLoaded;
 

--- a/src/main/java/com/forgeessentials/multiworld/MultiworldManager.java
+++ b/src/main/java/com/forgeessentials/multiworld/MultiworldManager.java
@@ -131,7 +131,9 @@ public class MultiworldManager extends ServerEventHandler implements NamedWorldH
             try
             {
                 registerWorld(world);
-                loadWorld(world);
+                if (world.loadOnServerStart) {
+                    loadWorld(world);
+                }
             }
             catch (MultiworldException e)
             {


### PR DESCRIPTION
Tested on my test server following cases:
- set the option to true, restart the server -> Dimension does load
- set the option to false, restart the server -> Dimension does not load
- set the option to false, restart the server, log-in -> Dimension does load on login fine, even if not loaded on server start