### PR TITLE
Fix update checker

### DIFF
--- a/src/utils/java/com/forgeessentials/commons/ServerVersionChecker.java
+++ b/src/utils/java/com/forgeessentials/commons/ServerVersionChecker.java
@@ -47,7 +47,9 @@ public class ServerVersionChecker {
 	            	BuildInfo.minorNumberLatest = Integer.parseInt(values[2]);
 	                continue;
 	            }
-	            if (Integer.parseInt(values[2]) > BuildInfo.MINOR_VERSION && Integer.parseInt(values[1]) >= Integer.parseInt(BuildInfo.MAJOR_VERSION))
+	            if (Integer.parseInt(values[2]) > BuildInfo.MINOR_VERSION 
+	            		&& Integer.parseInt(values[2]) > BuildInfo.minorNumberLatest
+	            		&& Integer.parseInt(values[1]) >= Integer.parseInt(BuildInfo.MAJOR_VERSION))
 	            {
 	            	BuildInfo.majorNumberLatest = Integer.parseInt(values[1]);
 	            	BuildInfo.minorNumberLatest = Integer.parseInt(values[2]);


### PR DESCRIPTION
Fixes the update checker using the minor version of the last tag it scans, not the highest value one, if there is no major update.