### PR TITLE
lower-case gamemode names for tab completion options

### DIFF
--- a/src/main/java/com/forgeessentials/commands/player/CommandGameMode.java
+++ b/src/main/java/com/forgeessentials/commands/player/CommandGameMode.java
@@ -193,7 +193,7 @@ public class CommandGameMode extends ForgeEssentialsCommandBase
 
             for (int i = 0; i < allGameTypes.length; i++)
             {
-                names[i] = allGameTypes[i].getName();
+                names[i] = allGameTypes[i].getName().toLowerCase();
             }
 
             return getListOfStringsMatchingLastWord(args, names);


### PR DESCRIPTION
Mostly cosmetic. It didn't bother me yesterday but it does today. All names are lower-case and (for some reasons) the names from mods might be upper-case and that doesn't look nice. :D