### PR TITLE
Fix Broken ASM logic by not running ASM at the tweaker stage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,6 +168,7 @@ ext.serverManifest = manifest {
 	attributes (
 		"TweakClass": "com.forgeessentials.core.preloader.FELaunchHandler",
 		"TweakOrder": "0",
+        "FMLCorePlugin": "com.forgeessentials.core.preloader.FELoadingPlugin",
 		"MixinConfigs": "mixins.forgeessentials.json,mixins.forgeessentials-opt.json",
 		"FMLAT": "forgeessentials_at.cfg",
 	)

--- a/src/main/java/com/forgeessentials/core/preloader/FELaunchHandler.java
+++ b/src/main/java/com/forgeessentials/core/preloader/FELaunchHandler.java
@@ -147,7 +147,6 @@ public class FELaunchHandler implements ITweaker
             extractLibraries();
         loadLibraries(classLoader);
         loadModules(classLoader);
-        classLoader.registerTransformer(EventTransformer.class.getName());
     }
 
     /* ------------------------------------------------------------ */

--- a/src/main/java/com/forgeessentials/core/preloader/FELoadingPlugin.java
+++ b/src/main/java/com/forgeessentials/core/preloader/FELoadingPlugin.java
@@ -1,0 +1,32 @@
+package com.forgeessentials.core.preloader;
+
+import java.util.Map;
+import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
+
+public class FELoadingPlugin implements IFMLLoadingPlugin
+{
+    @Override public String[] getASMTransformerClass()
+    {
+        return new String[] { EventTransformer.class.getName() };
+    }
+
+    @Override public String getModContainerClass()
+    {
+        return null;
+    }
+
+    @Override public String getSetupClass()
+    {
+        return null;
+    }
+
+    @Override public void injectData(Map<String, Object> map)
+    {
+
+    }
+
+    @Override public String getAccessTransformerClass()
+    {
+        return null;
+    }
+}

--- a/src/main/resources/mixins.forgeessentials.json
+++ b/src/main/resources/mixins.forgeessentials.json
@@ -8,7 +8,7 @@
       "block.MixinBlockEndPortal",
       "block.MixinBlockFire",
       "block.MixinBlockPortal",
-      "block.MixinBlockFarmland",
+      //"block.MixinBlockFarmland",
       "command.MixinCommandHandler",
       "entity.MixinEntity",
       "entity.MixinEntityTracker",


### PR DESCRIPTION
Old Logic was trying to inject the ASM too early and from what I could find, there seems to be a separate class loader at that stage and the normal MC classes are never injected.