### PR TITLE
Attempt to fix NPCs not being registered correctly

### DIFF
--- a/src/main/java/com/forgeessentials/api/UserIdent.java
+++ b/src/main/java/com/forgeessentials/api/UserIdent.java
@@ -16,6 +16,7 @@ import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.common.util.FakePlayerFactory;
 
+import com.forgeessentials.core.ForgeEssentials;
 import com.forgeessentials.permissions.ModulePermissions;
 import com.forgeessentials.util.ServerUtil;
 import com.forgeessentials.util.UserIdentUtils;
@@ -23,6 +24,7 @@ import com.forgeessentials.util.output.LoggingHandler;
 import com.google.gson.annotations.Expose;
 import com.mojang.authlib.GameProfile;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.Event;
 
 import javax.annotation.Nullable;
@@ -175,7 +177,8 @@ public class UserIdent
                 }
                 return ident;
             }
-            if (username.startsWith("$NPC"))
+
+            if (username.startsWith("$NPC") || username.startsWith("[") || UUID.nameUUIDFromBytes(username.getBytes()).equals(uuid))
             {
                 return new NpcUserIdent(uuid, username);
             }
@@ -221,15 +224,10 @@ public class UserIdent
 
     public static synchronized UserIdent get(EntityPlayer player)
     {
-        return player instanceof EntityPlayerMP ? get((EntityPlayerMP) player) : null;
-    }
-
-    public static synchronized UserIdent get(EntityPlayerMP player)
-    {
         if (player == null)
             throw new IllegalArgumentException();
         
-        if (player instanceof FakePlayer) {
+        if (!(player instanceof EntityPlayerMP) || player instanceof FakePlayer) {
             return getNpc(player.getDisplayName(), ModulePermissions.fakePlayerIsSpecialBunny ? null : player.getPersistentID());
         }
 
@@ -249,7 +247,7 @@ public class UserIdent
                 }
             }
             else
-                ident = new UserIdent(player);
+                ident = new UserIdent((EntityPlayerMP) player);
         }
         else
         {
@@ -326,7 +324,7 @@ public class UserIdent
         if (ident == null)
             ident = byUsername.get(username);
 
-        if (ident == null || !(ident instanceof ServerUserIdent))
+        if (!(ident instanceof ServerUserIdent))
             ident = new ServerUserIdent(_uuid, username);
 
         return (ServerUserIdent) ident;

--- a/src/main/java/com/forgeessentials/permissions/core/ZonedPermissionHelper.java
+++ b/src/main/java/com/forgeessentials/permissions/core/ZonedPermissionHelper.java
@@ -756,9 +756,6 @@ public class ZonedPermissionHelper extends ServerEventHandler implements IPermis
         else if (player != null)
             ident = UserIdent.get(player);
 
-        if (ident == null && player != null)
-            ident = UserIdent.get(player.getUniqueID(), player.getDisplayName());
-
         if (context.getTargetLocationStart() != null)
         {
             if (context.getTargetLocationEnd() != null)

--- a/src/main/java/com/forgeessentials/util/PlayerInfo.java
+++ b/src/main/java/com/forgeessentials/util/PlayerInfo.java
@@ -9,6 +9,7 @@ import com.forgeessentials.data.v2.Loadable;
 import com.forgeessentials.util.events.FEPlayerEvent.ClientHandshakeEstablished;
 import com.forgeessentials.util.events.FEPlayerEvent.InventoryGroupChange;
 import com.forgeessentials.util.events.FEPlayerEvent.NoPlayerInfoEvent;
+import com.forgeessentials.util.output.LoggingHandler;
 import com.google.gson.annotations.Expose;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -150,7 +151,12 @@ public class PlayerInfo implements Loadable
      */
     public void save()
     {
-        DataManager.getInstance().save(this, ident.getUuid().toString());
+        if (ident.hasUuid())
+        {
+            DataManager.getInstance().save(this, ident.getUuid().toString());
+        } else {
+            LoggingHandler.felog.fatal("Unable to save player-info for {} because UUID is null!", ident.getUsername());
+        }
     }
 
     public boolean isLoggedIn()


### PR DESCRIPTION
Also add a null ptr sanity check to PlayerInfo
(specifically, due to the previous issue with NPCs) Also, log these failures as Fatal for tracking purposes (Ideally, the fix above should prevent them)