### PR TITLE
1.12.2/develop add public JScripting method to parse UserIdent from string input

### DIFF
--- a/jscripting/fe.d.ts
+++ b/jscripting/fe.d.ts
@@ -54,6 +54,7 @@ declare namespace fe {
 		parsePlayer(): UserIdent;
 		parsePlayer(mustExist: boolean): UserIdent;
 		parsePlayer(mustExist: boolean, mustBeOnline: boolean): UserIdent;
+		parsePlayer(name: string, mustExist: boolean, mustBeOnline: boolean): UserIdent;
 		parseItem(): mc.item.Item;
 		parseBlock(): mc.world.Block;
 		parsePermission(): string;

--- a/src/main/java/com/forgeessentials/jscripting/fewrapper/fe/JsCommandArgs.java
+++ b/src/main/java/com/forgeessentials/jscripting/fewrapper/fe/JsCommandArgs.java
@@ -132,6 +132,11 @@ public class JsCommandArgs extends JsWrapper<CommandParserArgs>
         return new JsUserIdent(that.parsePlayer(mustExist, mustBeOnline));
     }
 
+    public JsUserIdent parsePlayer(String name, boolean mustExist, boolean mustBeOnline) throws CommandException
+    {
+        return new JsUserIdent(that.parsePlayer(name, mustExist, mustBeOnline));
+    }
+
     public JsItem parseItem() throws CommandException
     {
         return JsItem.get(that.parseItem());

--- a/src/main/java/com/forgeessentials/util/CommandParserArgs.java
+++ b/src/main/java/com/forgeessentials/util/CommandParserArgs.java
@@ -186,6 +186,23 @@ public class CommandParserArgs
         }
     }
 
+    public UserIdent parsePlayer(String name, boolean mustExist, boolean mustBeOnline) throws CommandException
+    {
+        if (name == null)
+        {
+            return parsePlayer(mustExist, mustBeOnline);
+        }
+        else
+        {
+            UserIdent ident = UserIdent.get(name, null, mustExist);
+            if (mustExist && (ident == null || !ident.hasUuid()))
+                throw new TranslatedCommandException("Player %s not found", name);
+            else if (mustBeOnline && !ident.hasPlayer())
+                throw new TranslatedCommandException("Player %s is not online", name);
+            return ident;
+        }
+    }
+
     public static List<String> completePlayer(String arg)
     {
         Set<String> result = new TreeSet<>();

--- a/src/main/resources/com/forgeessentials/jscripting/fe.d.ts
+++ b/src/main/resources/com/forgeessentials/jscripting/fe.d.ts
@@ -54,6 +54,7 @@ declare namespace fe {
 		parsePlayer(): UserIdent;
 		parsePlayer(mustExist: boolean): UserIdent;
 		parsePlayer(mustExist: boolean, mustBeOnline: boolean): UserIdent;
+		parsePlayer(name: string, mustExist: boolean, mustBeOnline: boolean): UserIdent;
 		parseItem(): mc.item.Item;
 		parseBlock(): mc.world.Block;
 		parsePermission(): string;


### PR DESCRIPTION
This is a backport from functionality available in 1.16.5 onwards, where custom JScripts have the option of getting a `UserIdent` from just a string name that has been provided.

---

Currently in 1.12.2 and below, if you wish to write a JScript that, for example, compares a user's playtime to all others currently online in a server, this cannot be done easily. The workaround currently is to get `UserIdent`s for all players that exist, get the `String` list of online players, and then do a filter and subtraction to get the result. This is costly, particularly for `setInterval` usage

This functionality was added alongside the deprecation of the old methods during the command system rewrite, part 29 (https://github.com/ForgeEssentials/ForgeEssentials/commit/37d05ecb328749c422337f0254416833e2b67779).

---

The approach I've taken is to add this functionality as a 4th overload. Whilst it does cause a bit of duplication, in this instance, it also allows previously written JScripts to be backwards compatible with the change. Since the 1.12.2 branch isn't in active development, the deprecated overloads shouldn't be modified if it can be helped.

If for some reason a JScript user fails to pass a `String` name into this new method, execution is handed to the old methods, and continues as normal.