### PR TITLE
1.7.10/develop add public JScripting method to parse UserIdent from string input

### DIFF
--- a/jscripting/fe.d.ts
+++ b/jscripting/fe.d.ts
@@ -52,6 +52,7 @@ declare namespace fe {
 		parsePlayer(): UserIdent;
 		parsePlayer(mustExist: boolean): UserIdent;
 		parsePlayer(mustExist: boolean, mustBeOnline: boolean): UserIdent;
+		parsePlayer(name: string, mustExist: boolean, mustBeOnline: boolean): UserIdent;
 		parseItem(): mc.item.Item;
 		parseBlock(): mc.world.Block;
 		parsePermission(): string;

--- a/src/main/java/com/forgeessentials/jscripting/fewrapper/fe/JsCommandArgs.java
+++ b/src/main/java/com/forgeessentials/jscripting/fewrapper/fe/JsCommandArgs.java
@@ -113,6 +113,11 @@ public class JsCommandArgs extends JsWrapper<CommandParserArgs>
         return new JsUserIdent(that.parsePlayer(mustExist, mustBeOnline));
     }
 
+    public JsUserIdent parsePlayer(String name, boolean mustExist, boolean mustBeOnline) throws CommandException
+    {
+        return new JsUserIdent(that.parsePlayer(name, mustExist, mustBeOnline));
+    }
+
     public JsItem parseItem()
     {
         return JsItem.get(that.parseItem());

--- a/src/main/java/com/forgeessentials/util/CommandParserArgs.java
+++ b/src/main/java/com/forgeessentials/util/CommandParserArgs.java
@@ -185,6 +185,23 @@ public class CommandParserArgs
         }
     }
 
+    public UserIdent parsePlayer(String name, boolean mustExist, boolean mustBeOnline) throws CommandException
+    {
+        if (name == null)
+        {
+            return parsePlayer(mustExist, mustBeOnline);
+        }
+        else
+        {
+            UserIdent ident = UserIdent.get(name, null, mustExist);
+            if (mustExist && (ident == null || !ident.hasUuid()))
+                throw new TranslatedCommandException("Player %s not found", name);
+            else if (mustBeOnline && !ident.hasPlayer())
+                throw new TranslatedCommandException("Player %s is not online", name);
+            return ident;
+        }
+    }
+
     public static List<String> completePlayer(String arg)
     {
         Set<String> result = new TreeSet<>();

--- a/src/main/resources/com/forgeessentials/jscripting/fe.d.ts
+++ b/src/main/resources/com/forgeessentials/jscripting/fe.d.ts
@@ -52,6 +52,7 @@ declare namespace fe {
 		parsePlayer(): UserIdent;
 		parsePlayer(mustExist: boolean): UserIdent;
 		parsePlayer(mustExist: boolean, mustBeOnline: boolean): UserIdent;
+		parsePlayer(name: string, mustExist: boolean, mustBeOnline: boolean): UserIdent;
 		parseItem(): mc.item.Item;
 		parseBlock(): mc.world.Block;
 		parsePermission(): string;


### PR DESCRIPTION
See https://github.com/ForgeEssentials/ForgeEssentials/pull/2681 for details.

---

This is the exact same backport as mentioned at #2681 but for 1.7.10. There does not seem to be any glaring bugs after testing, but I am not familiar with FE 1.7.10 so if anyone more knowledgable can double check for this specific version, that would be appreciated 👍