### PR TITLE
1.12.2/develop update Chat module for msg/tell/r/pm and gmsg logging

### DIFF
--- a/src/main/java/com/forgeessentials/chat/ChatConfig.java
+++ b/src/main/java/com/forgeessentials/chat/ChatConfig.java
@@ -57,6 +57,8 @@ public class ChatConfig extends ConfigLoaderBase
 
     public static boolean logIRC;
 
+    public static boolean logDiscord;
+
     @Override
     public void load(Configuration config, boolean isReload)
     {
@@ -88,6 +90,7 @@ public class ChatConfig extends ConfigLoaderBase
         coloredTabMenuEnabled = config.getBoolean(CAT_SB, "Enabled", false, "Whether or not to enable the tab menu colors");
 
         logChat = config.get(CAT_LOG, "LogChat", true, "Log all publicly visible chat messages.").getBoolean(true);
+        logDiscord = config.get(CAT_LOG, "LogDiscord", true, "If Discord is enabled, then log Discord chat too.").getBoolean(true);
         logGroupChat = config.get(CAT_LOG, "LogGroupChats", true, "Log all chats sent to groups.").getBoolean(true);
         logIRC = config.get(CAT_LOG, "LogIRC", true, "If IRC is enabled, then log IRC chat too. Excludes /ircpm, unless LogTells is also enabled.").getBoolean(true);
         logTells = config.get(CAT_LOG, "LogTells", true, "Log all /msg, /pm, /tell, /r chats. Includes /ircpm, if LogIRC is also enabled.").getBoolean(true);

--- a/src/main/java/com/forgeessentials/chat/ChatConfig.java
+++ b/src/main/java/com/forgeessentials/chat/ChatConfig.java
@@ -17,6 +17,8 @@ public class ChatConfig extends ConfigLoaderBase
 
     private static final String CAT_GM = CATEGORY + ".Gamemodes";
 
+    private static final String CAT_LOG = CATEGORY + ".Logging";
+
     public static final String CHAT_FORMAT_HELP = "Format for chat. Always needs to contain all 5 \"%s\" placeholders like the default!";
 
     private static final String MUTEDCMD_HELP = "All commands in here will be blocked if the player is muted.";
@@ -47,6 +49,12 @@ public class ChatConfig extends ConfigLoaderBase
 
     public static boolean coloredTabMenuEnabled;
 
+    public static boolean logChat;
+
+    public static boolean logTells;
+
+    public static boolean logGroupChat;
+
     @Override
     public void load(Configuration config, boolean isReload)
     {
@@ -76,7 +84,11 @@ public class ChatConfig extends ConfigLoaderBase
             mutedCommands.add(cmd);
 
         coloredTabMenuEnabled = config.getBoolean(CAT_SB, "Enabled", false, "Whether or not to enable the tab menu colors");
-        ModuleChat.instance.setChatLogging(config.get(CATEGORY, "LogChat", true, "Log all chat messages").getBoolean(true));
+
+        logChat = config.get(CAT_LOG, "LogChat", true, "Log all publicly visible chat messages.").getBoolean(true);
+        logGroupChat = config.get(CAT_LOG, "LogGroupChats", true, "Log all chats sent to groups.").getBoolean(true);
+        logTells = config.get(CAT_LOG, "LogTells", true, "Log all /msg, /PM, /tell, and /r chats.").getBoolean(true);
+        ModuleChat.instance.setChatLogging();
     }
 
     @Override

--- a/src/main/java/com/forgeessentials/chat/ChatConfig.java
+++ b/src/main/java/com/forgeessentials/chat/ChatConfig.java
@@ -89,8 +89,8 @@ public class ChatConfig extends ConfigLoaderBase
 
         logChat = config.get(CAT_LOG, "LogChat", true, "Log all publicly visible chat messages.").getBoolean(true);
         logGroupChat = config.get(CAT_LOG, "LogGroupChats", true, "Log all chats sent to groups.").getBoolean(true);
-        logIRC = config.get(CAT_LOG, "LogIRC", true, "If IRC is enabled, then log all IRC chat too.").getBoolean(true);
-        logTells = config.get(CAT_LOG, "LogTells", true, "Log all /msg, /PM, /tell, and /r chats.").getBoolean(true);
+        logIRC = config.get(CAT_LOG, "LogIRC", true, "If IRC is enabled, then log IRC chat too. Excludes /ircpm, unless LogTells is also enabled.").getBoolean(true);
+        logTells = config.get(CAT_LOG, "LogTells", true, "Log all /msg, /pm, /tell, /r chats. Includes /ircpm, if LogIRC is also enabled.").getBoolean(true);
         ModuleChat.instance.setChatLogging();
     }
 

--- a/src/main/java/com/forgeessentials/chat/ChatConfig.java
+++ b/src/main/java/com/forgeessentials/chat/ChatConfig.java
@@ -55,6 +55,8 @@ public class ChatConfig extends ConfigLoaderBase
 
     public static boolean logGroupChat;
 
+    public static boolean logIRC;
+
     @Override
     public void load(Configuration config, boolean isReload)
     {
@@ -87,6 +89,7 @@ public class ChatConfig extends ConfigLoaderBase
 
         logChat = config.get(CAT_LOG, "LogChat", true, "Log all publicly visible chat messages.").getBoolean(true);
         logGroupChat = config.get(CAT_LOG, "LogGroupChats", true, "Log all chats sent to groups.").getBoolean(true);
+        logIRC = config.get(CAT_LOG, "LogIRC", true, "If IRC is enabled, then log all IRC chat too.").getBoolean(true);
         logTells = config.get(CAT_LOG, "LogTells", true, "Log all /msg, /PM, /tell, and /r chats.").getBoolean(true);
         ModuleChat.instance.setChatLogging();
     }

--- a/src/main/java/com/forgeessentials/chat/ModuleChat.java
+++ b/src/main/java/com/forgeessentials/chat/ModuleChat.java
@@ -544,9 +544,18 @@ public class ModuleChat
                 new Object[] { target.getDisplayName(), message });
         sentMsg.getStyle().setColor(TextFormatting.GRAY).setItalic(Boolean.valueOf(true));
         senderMsg.getStyle().setColor(TextFormatting.GRAY).setItalic(Boolean.valueOf(true));
+        boolean isIRC = (sender.getName().matches("^IRC:(.*)") || target.getName().matches("^IRC:(.*)"));
         if (ChatConfig.logTells)
         {
-            ModuleChat.instance.logChatMessage(sender.getName(), message.getUnformattedText(), target.getName());
+            // if IRC logging is disabled, and the tell message has an IRC user...
+            if (!ChatConfig.logIRC && isIRC)
+            {
+                // ...then do nothing.
+            }
+            else // otherwise, log this tell to file
+            {
+                ModuleChat.instance.logChatMessage(sender.getName(), message.getUnformattedText(), target.getName());
+            }
         }
         ChatOutputHandler.sendMessage(target, sentMsg);
         ChatOutputHandler.sendMessage(sender, senderMsg);

--- a/src/main/java/com/forgeessentials/chat/ModuleChat.java
+++ b/src/main/java/com/forgeessentials/chat/ModuleChat.java
@@ -245,8 +245,11 @@ public class ModuleChat
             return;
         }
 
-        // Log chat message
-        logChatMessage(event.getPlayer().getName(), event.getMessage());
+        // Log chat message, if config is set
+        if (ChatConfig.logChat)
+        {
+            logChatMessage(event.getPlayer().getName(), event.getMessage());
+        }
 
         // Initialize parameters
         String message = processChatReplacements(event.getPlayer(), censor.filter(event.getMessage(), event.getPlayer()), false);
@@ -475,8 +478,14 @@ public class ModuleChat
         logWriter.write(logMessage + "\n");
     }
 
-    public void setChatLogging(boolean enabled)
+    public void setChatLogging()
     {
+        boolean enabled = false;
+        // if any of the chat logging forms are requested in config, then create a writer
+        if (ChatConfig.logChat || ChatConfig.logGroupChat || ChatConfig.logTells)
+        {
+            enabled = true;
+        }
         if (logWriter != null && enabled)
             return;
         closeLog();
@@ -539,7 +548,10 @@ public class ModuleChat
                 new Object[] { target.getDisplayName(), message });
         sentMsg.getStyle().setColor(TextFormatting.GRAY).setItalic(Boolean.valueOf(true));
         senderMsg.getStyle().setColor(TextFormatting.GRAY).setItalic(Boolean.valueOf(true));
-        ModuleChat.instance.logChatMessage(sender.getName(), message.getUnformattedText(), target.getName());
+        if (ChatConfig.logTells)
+        {
+            ModuleChat.instance.logChatMessage(sender.getName(), message.getUnformattedText(), target.getName());
+        }
         ChatOutputHandler.sendMessage(target, sentMsg);
         ChatOutputHandler.sendMessage(sender, senderMsg);
         CommandReply.messageSent(sender, target);
@@ -572,7 +584,10 @@ public class ModuleChat
         msgBody.getStyle().setColor(TextFormatting.GRAY);
         msg.appendSibling(msgBody);
 
-        ModuleChat.instance.logChatMessage(sender.getName(), formatted, ("@" + groupName + "@ "));
+        if (ChatConfig.logGroupChat)
+        {
+            ModuleChat.instance.logChatMessage(sender.getName(), formatted, ("@" + groupName + "@ "));
+        }
 
         for (EntityPlayerMP p : ServerUtil.getPlayerList())
         {

--- a/src/main/java/com/forgeessentials/chat/ModuleChat.java
+++ b/src/main/java/com/forgeessentials/chat/ModuleChat.java
@@ -539,6 +539,7 @@ public class ModuleChat
                 new Object[] { target.getDisplayName(), message });
         sentMsg.getStyle().setColor(TextFormatting.GRAY).setItalic(Boolean.valueOf(true));
         senderMsg.getStyle().setColor(TextFormatting.GRAY).setItalic(Boolean.valueOf(true));
+        ModuleChat.instance.logChatMessage(sender.getName(), message.getUnformattedText(), target.getName());
         ChatOutputHandler.sendMessage(target, sentMsg);
         ChatOutputHandler.sendMessage(sender, senderMsg);
         CommandReply.messageSent(sender, target);
@@ -570,6 +571,8 @@ public class ModuleChat
         ITextComponent msgBody = new TextComponentString(formatted);
         msgBody.getStyle().setColor(TextFormatting.GRAY);
         msg.appendSibling(msgBody);
+
+        ModuleChat.instance.logChatMessage(sender.getName(), formatted, ("@" + groupName + "@ "));
 
         for (EntityPlayerMP p : ServerUtil.getPlayerList())
         {

--- a/src/main/java/com/forgeessentials/chat/ModuleChat.java
+++ b/src/main/java/com/forgeessentials/chat/ModuleChat.java
@@ -456,9 +456,22 @@ public class ModuleChat
 
     public void logChatMessage(String sender, String message)
     {
+        logChatMessage(sender, message, null);
+    }
+
+    public void logChatMessage(String sender, String message, String recipient)
+    {
+        String logMessage;
         if (logWriter == null)
             return;
-        String logMessage = String.format("[%1$tY-%1$tm-%1$te %1$tH:%1$tM:%1$tS] %2$s: %3$s", new Date(), sender, message);
+        if (recipient == null)
+        {
+            logMessage = String.format("[%1$tY-%1$tm-%1$te %1$tH:%1$tM:%1$tS] %2$s: %3$s", new Date(), sender, message);
+        }
+        else
+        {
+            logMessage = String.format("[%1$tY-%1$tm-%1$te %1$tH:%1$tM:%1$tS] %2$s -> %3$s: %4$s", new Date(), sender, recipient, message);
+        }
         logWriter.write(logMessage + "\n");
     }
 

--- a/src/main/java/com/forgeessentials/chat/ModuleChat.java
+++ b/src/main/java/com/forgeessentials/chat/ModuleChat.java
@@ -480,12 +480,8 @@ public class ModuleChat
 
     public void setChatLogging()
     {
-        boolean enabled = false;
+        boolean enabled = ChatConfig.logChat || ChatConfig.logGroupChat || ChatConfig.logTells || ChatConfig.logIRC;
         // if any of the chat logging forms are requested in config, then create a writer
-        if (ChatConfig.logChat || ChatConfig.logGroupChat || ChatConfig.logTells)
-        {
-            enabled = true;
-        }
         if (logWriter != null && enabled)
             return;
         closeLog();

--- a/src/main/java/com/forgeessentials/chat/discord/DiscordHandler.java
+++ b/src/main/java/com/forgeessentials/chat/discord/DiscordHandler.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.forgeessentials.chat.ChatConfig;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.entities.Guild;
@@ -142,6 +143,10 @@ public class DiscordHandler extends ConfigLoaderBase
                 String suffix = String.format("<%s> %s", event.getMember().getEffectiveName(),
                         event.getMessage().getContentDisplay());
                 String msg = selectedChannel.equals(event.getChannel().getName()) ? suffix : String.format("#%s %s", event.getChannel().getName(), suffix);
+                if (ChatConfig.logDiscord)
+                {
+                    ModuleChat.instance.logChatMessage("Discord:" + event.getChannel().getName() + ":" + event.getMember().getEffectiveName(), event.getMessage().getContentDisplay());
+                }
                 ChatOutputHandler.broadcast(msg, false);
             }
         }

--- a/src/main/java/com/forgeessentials/chat/irc/IrcHandler.java
+++ b/src/main/java/com/forgeessentials/chat/irc/IrcHandler.java
@@ -314,7 +314,7 @@ public class IrcHandler extends ListenerAdapter<PircBotX> implements ConfigLoade
         String filteredMessage = ModuleChat.censor.filterIRC(message);
         if (ChatConfig.logIRC)
         {
-            ModuleChat.instance.logChatMessage("IRC-" + user.getNick(), filteredMessage);
+            ModuleChat.instance.logChatMessage("IRC:" + user.getNick(), filteredMessage);
         }
         String headerText = String.format(ircHeader, user.getNick());
         ITextComponent header = ModuleChat.clickChatComponent(headerText, Action.SUGGEST_COMMAND, "/ircpm " + user.getNick() + " ");

--- a/src/main/java/com/forgeessentials/chat/irc/IrcHandler.java
+++ b/src/main/java/com/forgeessentials/chat/irc/IrcHandler.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.forgeessentials.chat.ChatConfig;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommand;
 import net.minecraft.command.ICommandSender;
@@ -311,8 +312,10 @@ public class IrcHandler extends ListenerAdapter<PircBotX> implements ConfigLoade
     private void mcSendMessage(String message, User user)
     {
         String filteredMessage = ModuleChat.censor.filterIRC(message);
-        ModuleChat.instance.logChatMessage("IRC-" + user.getNick(), filteredMessage);
-
+        if (ChatConfig.logChat)
+        {
+            ModuleChat.instance.logChatMessage("IRC-" + user.getNick(), filteredMessage);
+        }
         String headerText = String.format(ircHeader, user.getNick());
         ITextComponent header = ModuleChat.clickChatComponent(headerText, Action.SUGGEST_COMMAND, "/ircpm " + user.getNick() + " ");
         ITextComponent messageComponent = ModuleChat.filterChatLinks(ChatOutputHandler.formatColors(filteredMessage));

--- a/src/main/java/com/forgeessentials/chat/irc/IrcHandler.java
+++ b/src/main/java/com/forgeessentials/chat/irc/IrcHandler.java
@@ -312,7 +312,7 @@ public class IrcHandler extends ListenerAdapter<PircBotX> implements ConfigLoade
     private void mcSendMessage(String message, User user)
     {
         String filteredMessage = ModuleChat.censor.filterIRC(message);
-        if (ChatConfig.logChat)
+        if (ChatConfig.logIRC)
         {
             ModuleChat.instance.logChatMessage("IRC-" + user.getNick(), filteredMessage);
         }


### PR DESCRIPTION
This update modifies chat logging to log all chat messages received by the server. The goal is to meet any potential compliance issues in the future.

---

Currently, only publicly available messages are logged in the FE chatlog output. It is technically possible to pull all other types of messages from the Minecraft base server `debug.log`, but this is cumbersome to do, and only the five most recent server runs are saved on rotation.

There are server admin issues arising from this. For example, if a few players are in an FE group, and are using their group chat to communicate, this chat is not visible to admins. Unless admins are a direct member of that group, they will not see the contents of this chat. A scenario where this is bad, would be if "trial" members of a server were abusing or spamming using /gmsg. An admin would be unaware of the problem, and unable to check chatlogs to verify afterwards.

Or, on a more serious note, there are safeguarding concerns regarding abuse that could happen through private messages on a server. In the unlikely event of such a case, it would be desirable to have access to PM and whisper logs that could be checked, and if relevant, turned over to authorities.

---

This PR adds logging for these categories, enabled by default, and included as part of the FE chat logging module. It comes with config options available in `Chat.cfg` that allow toggling of the individual types of logging: `LogChat`, `LogGroupChats`, and `LogTells`.

If any one of these three options is enabled, then FE chat logging is enabled for that category, and all three types write to the same file in sequence. If and only if all three options are set to `false`, then log file output is disabled entirely.

Logging for all three types is enabled by default, in case there is a compliance reason in the future. If the end-user chooses to disable logging, that's their prerogative, and it's not FE's fault. But, the option should be there for privacy conscious server admins, who perhaps run the server from jurisdictions that don't care.

