### PR TITLE
1.12.2/Fix mojang api url changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ modlist.txt
 /.apt_generated/
 /src/*/generated/
 /jscripting/tsconfig.json
+*.launch

--- a/src/main/java/com/forgeessentials/util/UserIdentUtils.java
+++ b/src/main/java/com/forgeessentials/util/UserIdentUtils.java
@@ -41,7 +41,7 @@ public class UserIdentUtils
 
     public static String resolveMissingUsername(UUID id)
     {
-        String url = "https://api.mojang.com/user/profiles/" + id.toString().replace("-", "") + "/names";
+    	String url = "https://sessionserver.mojang.com/session/minecraft/profile/" + id.toString().replace("-", "");
         return fetchData(url, "name");
     }
 


### PR DESCRIPTION
Mojang disabled the API to get a list of all past player names. This PR changes the call to get the profile data which includes the current name.