### PR TITLE
Fix Multiple issues with class loading on 1.12 that break discord module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ buildscript {
 	}
 	dependencies {
 		classpath "net.minecraftforge.gradle:ForgeGradle:5.1.68"
-		classpath "org.jfrog.buildinfo:build-info-extractor-gradle:3.0.1"
 		classpath "org.ajoberstar:gradle-git:0.12.0"
         classpath 'org.spongepowered:mixingradle:0.7-SNAPSHOT'
 		classpath("com.diffplug.gradle:goomph:3.42.2")

--- a/src/main/java/com/forgeessentials/core/preloader/FELaunchHandler.java
+++ b/src/main/java/com/forgeessentials/core/preloader/FELaunchHandler.java
@@ -125,11 +125,11 @@ public class FELaunchHandler implements ITweaker
         }
         catch (URISyntaxException ex)
         {
-            launchLog.error("Could not get JAR location for {}", uri);
+            launchLog.error("Could not get JAR location");
             ex.printStackTrace();
         }
         catch (Exception ex) {
-            launchLog.error("Unknown error attempting to get JAR location at {}",uri.getPath(), ex);
+            launchLog.error("Unknown error attempting to get JAR location at {}, Path: {}",uri, uri != null ? uri.getPath() : null, ex);
         }
     }
 


### PR DESCRIPTION
ex: Some classes like `org.apache.commons` are in an exclusion list and are loaded in the main classloader
Other classes like jackson databind are loaded by MC classes early on but don't exist yet Forge adds these to an invalid class list.  We have to remove these classes from this list. Also, fixed issues with extracting libraries if the directory can't be deleted Finally, added a blanket check for cases when the jar location could not be resolved as a file. Also, remove jfrog library since it broke the build on 1.7.10