### PR TITLE
Switch to using the name value here since it matches what the key value did in 1.7.10 code

### DIFF
--- a/src/main/java/com/forgeessentials/protection/ModuleProtection.java
+++ b/src/main/java/com/forgeessentials/protection/ModuleProtection.java
@@ -219,8 +219,8 @@ public class ModuleProtection
         for (Entry<ResourceLocation, EntityEntry> e : ForgeRegistries.ENTITIES.getEntries())
             if (EntityLiving.class.isAssignableFrom(e.getValue().getEntityClass()))
             {
-                APIRegistry.perms.registerPermission(PERM_MOBSPAWN_NATURAL + "." + e.getKey(), DefaultPermissionLevel.ALL, "");
-                APIRegistry.perms.registerPermission(PERM_MOBSPAWN_FORCED + "." + e.getKey(), DefaultPermissionLevel.ALL, "");
+                APIRegistry.perms.registerPermission(PERM_MOBSPAWN_NATURAL + "." + e.getValue().getName(), DefaultPermissionLevel.ALL, "");
+                APIRegistry.perms.registerPermission(PERM_MOBSPAWN_FORCED + "." + e.getValue().getName(), DefaultPermissionLevel.ALL, "");
             }
         for (MobType mobType : MobType.values())
         {


### PR DESCRIPTION
(the current key returns the full key instead of a unique name key)