### PR TITLE
fix buildscript using new version on gtnh maven (temporary fix)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 // Build repositories
 buildscript {
-	repositories {
+	repositories {		
+		maven {
+      		url = uri("https://plugins.gradle.org/m2/")
+    	}
 		maven {
 			name = "forge"
 			url = "https://files.minecraftforge.net/maven"
@@ -20,9 +23,6 @@ buildscript {
 			name = "sonatype"
 			url = "https://oss.sonatype.org/content/repositories/snapshots/"
 		}
-		maven {
-      		url = uri("https://plugins.gradle.org/m2/")
-    	}
 		jcenter()
 
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
 
 	}
 	dependencies {
-		classpath "net.minecraftforge.gradle:ForgeGradle:1.2.13"
+		classpath "net.minecraftforge.gradle:ForgeGradle:1.2.11.dirty"
 		classpath "org.ajoberstar:gradle-git:0.12.0"
 		classpath("com.modrinth.minotaur:Minotaur:2.8.3")
 	}


### PR DESCRIPTION
This is enough to fix the build, ideally the buildscript is migrated to a maintained toolchain though (rfg/unimined etc)